### PR TITLE
Geometry Dash

### DIFF
--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,24 @@ const defaultSubjects = {
   ]
 },
 
+"Geometry Dash": {
+  levels: [
+    "Stereo Madness","Back on Track","Polargeist","Dry Out","Base After Base","Can't Let Go","Jumper",
+    "Time Machine","Cycles","xStep","Clutterfunk","Theory of Everything","Electroman Adventures",
+    "Geometrical Dominator","Hexagon Force","Blast Processing","Electrodynamix","Clubstep","Theory of Everything 2",
+    "Deadlocked","ORBIT","LIMBO","Bloodbath","Top 10","Bloodshower","Purpular Rectanglisi (mer green)","Sonic Wave",
+    "Change of Scene","Absolute Garbage","HOW","WHAT","Grass","Nagatabi","Sunrise","Night City"
+  ],
+
+  gamemodes: [
+    "Cube","Robot","Ship","Ball","Wave","Spider","UFO","Swing Copter"
+  ],
+
+  structures: [
+    "Ekirby8 Tower","Clubstep Monster","Triple Spike"
+  ]
+},
+
 "Objects": {
   objects: [
     "Chair","Table","Sofa","Bed","Lamp","Mirror","Clock","Pillow","Blanket",


### PR DESCRIPTION
"Geometry Dash": {
  levels: [
    "Stereo Madness","Back on Track","Polargeist","Dry Out","Base After Base","Can't Let Go","Jumper",
    "Time Machine","Cycles","xStep","Clutterfunk","Theory of Everything","Electroman Adventures",
    "Geometrical Dominator","Hexagon Force","Blast Processing","Electrodynamix","Clubstep","Theory of Everything 2",
    "Deadlocked","ORBIT","LIMBO","Bloodbath","Top 10","Bloodshower","Purpular Rectanglisi (mer green)","Sonic Wave",
    "Change of Scene","Absolute Garbage","HOW","WHAT","Grass","Nagatabi","Sunrise","Night City"
  ],

  gamemodes: [
    "Cube","Robot","Ship","Ball","Wave","Spider","UFO","Swing Copter"
  ],

  structures: [
    "Ekirby8 Tower","Clubstep Monster","Triple Spike"
  ]
}